### PR TITLE
Add support for WAS Liberty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,111 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>was-liberty</id>
+      <build>
+        <defaultGoal>antrun:run install liberty:install-apps liberty:run-server</defaultGoal>
+        <plugins>
+          <plugin>
+            <groupId>net.wasdev.wlp.maven.plugins</groupId>
+            <artifactId>liberty-maven-plugin</artifactId>
+            <version>1.2-SNAPSHOT</version>
+            <configuration>
+              <assemblyArtifact>
+                <groupId>com.ibm.websphere.appserver.runtime</groupId>
+                <artifactId>wlp-javaee7</artifactId>
+                <version>8.5.5.7</version>
+                <type>zip</type>
+              </assemblyArtifact>
+              <assemblyInstallDirectory>/opt/ibm</assemblyInstallDirectory>
+              <configFile>${basedir}/tools/was-liberty/server.xml</configFile>
+              <!-- <appArchive>${project.build.directory}/${project.build.finalName}.war</appArchive> -->
+              <bootstrapProperties>
+                <!-- <appLocation>${project.build.directory}/${project.build.finalName}</appLocation>  -->
+                <settings.localRepository>${settings.localRepository}</settings.localRepository>
+                <derby.client.version>${derby.client.version}</derby.client.version>
+                <db.name>${db.name}</db.name>
+                <db.host>${db.host}</db.host>
+                <db.port>${db.port}</db.port>
+                <db.username>${db.username}</db.username>
+                <db.password>${db.password}</db.password>
+                <as.port>${as.port}</as.port>
+              </bootstrapProperties>
+              <!--
+              <appArtifact>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>${project.artifactId}</artifactId>
+                <version>${project.version}</version>
+                <type>war</type>
+              </appArtifact> -->
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.8</version>
+            <configuration>
+              <target>
+                <echo message="copy ibm-web-ext.xml"/>
+                <copy file="${basedir}/tools/was-liberty/ibm-web-ext.xml"
+                  tofile="${webappDirectory}/WEB-INF/ibm-web-ext.xml"/>
+                <copy file="${basedir}/tools/was-liberty/ibm-web-ext.xml"
+                  tofile="${project.build.directory}/${project.build.finalName}/WEB-INF/ibm-web-ext.xml"/>
+              </target>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>${project.artifactId}</artifactId>
+          <version>${project.version}</version>
+          <type>war</type>
+        </dependency>
+      </dependencies>
+      <repositories>
+        <repository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+          <id>ibm-maven-repo</id>
+          <name>ibm-maven-repo</name>
+          <url>http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/maven/repository/</url>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <releases>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+          <id>ibm-maven-repo</id>
+          <name>ibm-maven-repo</name>
+          <url>http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/maven/repository/</url>
+        </pluginRepository>
+        <pluginRepository>
+          <id>sonatype-nexus-snapshots</id>
+          <name>Sonatype Nexus Snapshots</name>
+          <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+
   </profiles>
 
 </project>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -21,6 +21,26 @@
     <param-name>javax.faces.PROJECT_STAGE</param-name>
     <param-value>Development</param-value>
   </context-param>
+  <servlet>
+    <servlet-name>Faces Servlet</servlet-name>
+    <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>Faces Servlet</servlet-name>
+    <url-pattern>*.xhtml</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>Faces Servlet</servlet-name>
+    <url-pattern>/faces/*</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>Faces Servlet</servlet-name>
+    <url-pattern>*.faces</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>Faces Servlet</servlet-name>
+    <url-pattern>*.jsf</url-pattern>
+  </servlet-mapping>
   <welcome-file-list>
     <welcome-file>index.xhtml</welcome-file>
   </welcome-file-list>

--- a/tools/was-liberty/ibm-web-ext.xml
+++ b/tools/was-liberty/ibm-web-ext.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-ext
+	xmlns="http://websphere.ibm.com/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd"
+	version="1.0">
+	<context-root uri="/"/>
+</web-ext>

--- a/tools/was-liberty/readme.md
+++ b/tools/was-liberty/readme.md
@@ -1,0 +1,17 @@
+## Usage (Windows)
+```bat
+set JAVA_HOME=<jdk installed directory>
+
+cd <projct base directory>
+start mvn -P derby
+mvn -P flyway
+mvn -P hibernate-tools
+
+set MAVEN_REPO=<maven local repository directory>
+mvn install
+start mvn -P was-liberty
+```
+
+## Open URL
+<http://localhost:8080/>
+

--- a/tools/was-liberty/server.xml
+++ b/tools/was-liberty/server.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+
+	<!-- Enable features -->
+	<featureManager>
+		<!-- <feature>javaee-7.0</feature> -->
+		<feature>jsf-2.2</feature>
+		<feature>jpa-2.1</feature>
+		<feature>cdi-1.2</feature>
+	</featureManager>
+
+	<!-- This template enables security. To get the full use of all the capabilities,
+		a keystore and user registry are required. -->
+
+	<!-- For the keystore, default keys are generated and stored in a keystore.
+		To provide the keystore password, generate an encoded password using bin/securityUtility
+		encode and add it below in the password attribute of the keyStore element.
+		Then uncomment the keyStore element. -->
+	<!-- <keyStore password=""/> -->
+
+	<!--For a user registry configuration, configure your user registry. For
+		example, configure a basic user registry using the basicRegistry element.
+		Specify your own user name below in the name attribute of the user element.
+		For the password, generate an encoded password using bin/securityUtility
+		encode and add it in the password attribute of the user element. Then uncomment
+		the user element. -->
+	<basicRegistry id="basic" realm="BasicRealm">
+		<!-- <user name="yourUserName" password="" /> -->
+	</basicRegistry>
+
+	<!-- To access this server from a remote client add a host attribute to
+		the following element, e.g. host="*" -->
+	<httpEndpoint id="defaultHttpEndpoint" httpPort="${as.port}" />
+
+	<dataSource id="javaee7-min-ds" jndiName="jdbc/javaee7-min-ds"
+		type="javax.sql.XADataSource">
+		<jdbcDriver libraryRef="DerbyLib" />
+		<properties.derby.client createDatabase="create"
+			databaseName="${db.name}" serverName="${db.host}" portNumber="${db.port}"
+			user="${db.username}" password="${db.password}" />
+	</dataSource>
+
+	<library id="DerbyLib">
+		<fileset dir="${env.MAVEN_REPO}/org/apache/derby/derbyclient/${derby.client.version}" />
+	</library>
+</server>


### PR DESCRIPTION
WAS Libertyサポートを追加しました。
glassfish-embedded との違いは下記です。
・debug は未サポート
・実行コマンドに違いあり -> tools/was-liberty/readme.md 参照
・デフォルトのインストール先は /opt/ibm
