### PR TITLE
liberty起動コマンド削減, glassfishパス問題の解消

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,26 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.0</version>
+        <executions>
+          <execution>
+            <id>convert-path-separator</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <source>
+project.properties['converted.build.directory']=project.build.directory.replace(File.separator,'/');
+project.properties['converted.localRepository']=settings.localRepository.replace(File.separator,'/');
+              </source>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -198,6 +218,7 @@
               <configFile>${project.build.directory}/domain.xml</configFile>
               <systemProperties>
                 <!-- <property>glassfish.embedded.tmpdir=${project.build.directory}</property> -->
+                <property>glassfish.embedded.tmpdir=${converted.build.directory}</property>
               </systemProperties>
             </configuration>
             <executions>
@@ -283,7 +304,17 @@
     <profile>
       <id>was-liberty</id>
       <build>
-        <defaultGoal>antrun:run install liberty:install-apps liberty:run-server</defaultGoal>
+        <defaultGoal>package liberty:run-server</defaultGoal>
+        <resources>
+          <resource>
+            <directory>${basedir}/tools/was-liberty</directory>
+            <includes>
+              <include>server.xml</include>
+            </includes>
+            <filtering>true</filtering>
+            <targetPath>${project.build.directory}</targetPath>
+          </resource>
+        </resources>
         <plugins>
           <plugin>
             <groupId>net.wasdev.wlp.maven.plugins</groupId>
@@ -296,12 +327,13 @@
                 <version>8.5.5.7</version>
                 <type>zip</type>
               </assemblyArtifact>
-              <assemblyInstallDirectory>/opt/ibm</assemblyInstallDirectory>
-              <configFile>${basedir}/tools/was-liberty/server.xml</configFile>
+              <!-- <assemblyInstallDirectory>/opt/ibm</assemblyInstallDirectory> -->
+              <configFile>${project.build.directory}/server.xml</configFile>
               <!-- <appArchive>${project.build.directory}/${project.build.finalName}.war</appArchive> -->
               <bootstrapProperties>
-                <!-- <appLocation>${project.build.directory}/${project.build.finalName}</appLocation>  -->
-                <settings.localRepository>${settings.localRepository}</settings.localRepository>
+                <appLocation>${converted.build.directory}/${project.build.finalName}</appLocation>
+                <appName>${project.artifactId}</appName>
+                <localRepository>${converted.localRepository}</localRepository>
                 <derby.client.version>${derby.client.version}</derby.client.version>
                 <db.name>${db.name}</db.name>
                 <db.host>${db.host}</db.host>
@@ -310,39 +342,10 @@
                 <db.password>${db.password}</db.password>
                 <as.port>${as.port}</as.port>
               </bootstrapProperties>
-              <!--
-              <appArtifact>
-                <groupId>${project.groupId}</groupId>
-                <artifactId>${project.artifactId}</artifactId>
-                <version>${project.version}</version>
-                <type>war</type>
-              </appArtifact> -->
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.8</version>
-            <configuration>
-              <target>
-                <echo message="copy ibm-web-ext.xml"/>
-                <copy file="${basedir}/tools/was-liberty/ibm-web-ext.xml"
-                  tofile="${webappDirectory}/WEB-INF/ibm-web-ext.xml"/>
-                <copy file="${basedir}/tools/was-liberty/ibm-web-ext.xml"
-                  tofile="${project.build.directory}/${project.build.finalName}/WEB-INF/ibm-web-ext.xml"/>
-              </target>
             </configuration>
           </plugin>
         </plugins>
       </build>
-      <dependencies>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>${project.artifactId}</artifactId>
-          <version>${project.version}</version>
-          <type>war</type>
-        </dependency>
-      </dependencies>
       <repositories>
         <repository>
           <releases>

--- a/tools/was-liberty/ibm-web-ext.xml
+++ b/tools/was-liberty/ibm-web-ext.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<web-ext
-	xmlns="http://websphere.ibm.com/xml/ns/javaee"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd"
-	version="1.0">
-	<context-root uri="/"/>
-</web-ext>

--- a/tools/was-liberty/readme.md
+++ b/tools/was-liberty/readme.md
@@ -7,8 +7,6 @@ start mvn -P derby
 mvn -P flyway
 mvn -P hibernate-tools
 
-set MAVEN_REPO=<maven local repository directory>
-mvn install
 start mvn -P was-liberty
 ```
 

--- a/tools/was-liberty/server.xml
+++ b/tools/was-liberty/server.xml
@@ -1,46 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <server description="new server">
 
-	<!-- Enable features -->
-	<featureManager>
-		<!-- <feature>javaee-7.0</feature> -->
-		<feature>jsf-2.2</feature>
-		<feature>jpa-2.1</feature>
-		<feature>cdi-1.2</feature>
-	</featureManager>
+  <!-- Enable features -->
+  <featureManager>
+    <!-- <feature>javaee-7.0</feature> -->
+    <feature>jsf-2.2</feature>
+    <feature>jpa-2.1</feature>
+    <feature>cdi-1.2</feature>
+  </featureManager>
 
-	<!-- This template enables security. To get the full use of all the capabilities,
-		a keystore and user registry are required. -->
+  <!-- This template enables security. To get the full use of all the capabilities,
+    a keystore and user registry are required. -->
 
-	<!-- For the keystore, default keys are generated and stored in a keystore.
-		To provide the keystore password, generate an encoded password using bin/securityUtility
-		encode and add it below in the password attribute of the keyStore element.
-		Then uncomment the keyStore element. -->
-	<!-- <keyStore password=""/> -->
+  <!-- For the keystore, default keys are generated and stored in a keystore.
+    To provide the keystore password, generate an encoded password using bin/securityUtility
+    encode and add it below in the password attribute of the keyStore element.
+    Then uncomment the keyStore element. -->
+  <!-- <keyStore password=""/> -->
 
-	<!--For a user registry configuration, configure your user registry. For
-		example, configure a basic user registry using the basicRegistry element.
-		Specify your own user name below in the name attribute of the user element.
-		For the password, generate an encoded password using bin/securityUtility
-		encode and add it in the password attribute of the user element. Then uncomment
-		the user element. -->
-	<basicRegistry id="basic" realm="BasicRealm">
-		<!-- <user name="yourUserName" password="" /> -->
-	</basicRegistry>
+  <!--For a user registry configuration, configure your user registry. For
+    example, configure a basic user registry using the basicRegistry element.
+    Specify your own user name below in the name attribute of the user element.
+    For the password, generate an encoded password using bin/securityUtility
+    encode and add it in the password attribute of the user element. Then uncomment
+    the user element. -->
+  <basicRegistry id="basic" realm="BasicRealm">
+    <!-- <user name="yourUserName" password="" /> -->
+  </basicRegistry>
 
-	<!-- To access this server from a remote client add a host attribute to
-		the following element, e.g. host="*" -->
-	<httpEndpoint id="defaultHttpEndpoint" httpPort="${as.port}" />
+  <!-- To access this server from a remote client add a host attribute to
+    the following element, e.g. host="*" -->
+  <httpEndpoint id="defaultHttpEndpoint" httpPort="${as.port}" />
 
-	<dataSource id="javaee7-min-ds" jndiName="jdbc/javaee7-min-ds"
-		type="javax.sql.XADataSource">
-		<jdbcDriver libraryRef="DerbyLib" />
-		<properties.derby.client createDatabase="create"
-			databaseName="${db.name}" serverName="${db.host}" portNumber="${db.port}"
-			user="${db.username}" password="${db.password}" />
-	</dataSource>
+  <dataSource id="javaee7-min-ds" jndiName="jdbc/javaee7-min-ds"
+    type="javax.sql.XADataSource">
+    <jdbcDriver libraryRef="DerbyLib" />
+    <properties.derby.client createDatabase="create"
+      databaseName="${db.name}" serverName="${db.host}" portNumber="${db.port}"
+      user="${db.username}" password="${db.password}" />
+  </dataSource>
 
-	<library id="DerbyLib">
-		<fileset dir="${env.MAVEN_REPO}/org/apache/derby/derbyclient/${derby.client.version}" />
-	</library>
+  <library id="DerbyLib">
+    <fileset dir="${localRepository}/org/apache/derby/derbyclient/${derby.client.version}" />
+  </library>
+  
+  <webApplication id="${appName}" location="${appLocation}" name="${appName}" contextRoot="/"/>
 </server>


### PR DESCRIPTION
パスセパレータ変換処理は共通処理として実装しているのでその辺ご確認ください。
全部変更とみなされる問題はWindowsのGitがデフォルトで改行自動変換設定になっていためでした。
下記コマンドで解消しました。

``` bat
$ git config --global core.autoCRLF false
```

変更の詳細は下記をご覧ください。

[詳細]
1.共通
・パスセパレータ変換処理「convert-path-separator」を追加
2.glassfish-embedded]
・Windows OSで「glassfish.embedded.tmpdir」プロパティに変数を使うと起動失敗する問題の解消
3.was-liberty
・起動コマンドの削減(環境変数「MAVEN_REP」設定, install)
・インストール先をデフォルト(ビルドディレクトリ)に変更
